### PR TITLE
Fix Wasm capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A Benchmark for WebAssembly (Wasm, WA) that uses [PSPDFKit for Web](https://pspdfkit.com/web/) Standalone.
 
-The rendering engine of [PSPDFKit for Web](https://pspdfkit.com/web/) Standalone is written in C/C++ and compiled to WASM.
+The rendering engine of [PSPDFKit for Web](https://pspdfkit.com/web/) Standalone is written in C/C++ and compiled to Wasm.
 
 Get your score in the [live demo](http://iswebassemblyfastyet.com/) and learn more in our [blog post](https://pspdfkit.com/blog/2018/a-real-world-webassembly-benchmark/).
 

--- a/src/lib/tests.js
+++ b/src/lib/tests.js
@@ -1,9 +1,9 @@
-import { isWASMSupported, clearAllTimings, isMobileOS } from "./utils";
+import { isWasmSupported, clearAllTimings, isMobileOS } from "./utils";
 import { createRunner } from "./runner";
 
 export function createBenchmark(pdf, licenseKey, conf) {
   // Factory to create our test suite. It will register all tests in the runner.
-  const isWasm = isWASMSupported() && !conf.disableWebAssembly;
+  const isWasm = isWasmSupported() && !conf.disableWebAssembly;
 
   const runner = createRunner(licenseKey);
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,5 +1,5 @@
 // This function takes a `duration` and subtracts the time to load chunks
-// (WASM artifacts) which otherwise would influence the final benchmark
+// (Wasm artifacts) which otherwise would influence the final benchmark
 // result.
 const ignoredResourceRegex = /.*pspdfkit.w?asm.*/;
 export function cleanupMeasurement(duration) {
@@ -77,10 +77,10 @@ export function getConfigOptionsFromURL() {
   };
 }
 
-// The same WASM test that is used in PSPDFKit for Web
-export function isWASMSupported() {
+// The same Wasm test that is used in PSPDFKit for Web
+export function isWasmSupported() {
   try {
-    // iOS ~11.2.2 has a known WASM problem.
+    // iOS ~11.2.2 has a known Wasm problem.
     // See: https://github.com/kripken/emscripten/issues/6042
     if (
       /iPad|iPhone|iPod/.test(navigator.userAgent) &&

--- a/src/ui/components/Benchmark.js
+++ b/src/ui/components/Benchmark.js
@@ -132,7 +132,7 @@ export default class Benchmark extends React.Component {
           data={tests["Test-Initialization"]}
           heading={
             isWasm
-              ? "Initialization: compilation and instantiation of the WASM module"
+              ? "Initialization: compilation and instantiation of the Wasm module"
               : "Initialization of PSPDFKit"
           }
           description={
@@ -188,7 +188,7 @@ export default class Benchmark extends React.Component {
               <div className="Result-score">
                 <div className="Score">
                   {isWasm && (
-                    <div className="Score-label">PSPDFKit WASM Score</div>
+                    <div className="Score-label">PSPDFKit Wasm Score</div>
                   )}
                   {!isWasm && (
                     <div className="Score-label">PSPDFKit JavaScript Score</div>

--- a/src/ui/components/Introduction.js
+++ b/src/ui/components/Introduction.js
@@ -28,7 +28,7 @@ export default function Introduction({ isWasm }) {
         {isWasm && (
           <p>
             You’re running the WebAssembly Benchmark! For browsers that don’t
-            support WASM, we made a benchmark that runs a JavaScript version of
+            support Wasm, we made a benchmark that runs a JavaScript version of
             PSPDFKit for Web.
             {isWasm && (
               <React.Fragment>


### PR DESCRIPTION
According to [the spec](https://webassembly.github.io/spec/core/intro/introduction.html#id1) Wasm is
> A contraction of “WebAssembly”, not an acronym, hence not using all-caps.

I don't have access to the header image to fix capitalization on it, but code and documentation now use same spelling as the spec.

Resolves #2.